### PR TITLE
Upgrade analyzer dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.19.5 <3.0.0'
 
 dependencies:
-  analyzer: ^2.0.0
+  analyzer: ^5.0.0
   aws_lambda_dart_runtime: ^1.0.3+2
   node_io: ^2.2.0
 


### PR DESCRIPTION
This upgrade is going to fix the AST generation for both Dart 2.19.6 and 3.0.0.

For analyzer version <= 5.0.0, the AST is not parsed correctly for Future returnType. 
E.g. `Future<List<int>> function()` is parsed as `dynamic function()`